### PR TITLE
Switched to new api for WhatsApp templates

### DIFF
--- a/src/Infobip.Api.SDK.Tests/Data/WhatsApp/CreateWhatsAppTemplateSuccess.json
+++ b/src/Infobip.Api.SDK.Tests/Data/WhatsApp/CreateWhatsAppTemplateSuccess.json
@@ -4,7 +4,8 @@
   "name": "exampleName",
   "language": "en",
   "status": "APPROVED",
-  "category": "ACCOUNT_UPDATE",
+  "category": "UTILITY",
+  "allowCategoryChange": false,
   "structure": {
     "header": {
       "format": "IMAGE"

--- a/src/Infobip.Api.SDK.Tests/Data/WhatsApp/CreateWhatsAppTemplateSuccess.json
+++ b/src/Infobip.Api.SDK.Tests/Data/WhatsApp/CreateWhatsAppTemplateSuccess.json
@@ -10,8 +10,8 @@
     "header": {
       "format": "IMAGE"
     },
-    "body": "example {{1}} body",
-    "footer": "exampleFooter",
+    "body": { "text": "example {{1}} body" },
+    "footer": { "text": "exampleFooter" },
     "type": "MEDIA"
   }
 }

--- a/src/Infobip.Api.SDK.Tests/Data/WhatsApp/GetWhatsAppTemplatesSuccess.json
+++ b/src/Infobip.Api.SDK.Tests/Data/WhatsApp/GetWhatsAppTemplatesSuccess.json
@@ -6,7 +6,7 @@
       "name": "exampleName",
       "language": "en",
       "status": "APPROVED",
-      "category": "ACCOUNT_UPDATE",
+      "category": "UTILITY",
       "structure": {
         "header": {
           "format": "IMAGE"

--- a/src/Infobip.Api.SDK.Tests/Data/WhatsApp/GetWhatsAppTemplatesSuccess.json
+++ b/src/Infobip.Api.SDK.Tests/Data/WhatsApp/GetWhatsAppTemplatesSuccess.json
@@ -11,10 +11,11 @@
         "header": {
           "format": "IMAGE"
         },
-        "body": "example {{1}} body",
-        "footer": "exampleFooter",
+        "body": { "text": "example {{1}} body" },
+        "footer": { "text": "exampleFooter" },
         "type": "MEDIA"
-      }
+      },
+      "quality": "UNKNOWN"
     }
   ]
 }

--- a/src/Infobip.Api.SDK.Tests/WhatsApp/CreateWhatsAppTemplateTests.cs
+++ b/src/Infobip.Api.SDK.Tests/WhatsApp/CreateWhatsAppTemplateTests.cs
@@ -120,7 +120,9 @@ namespace Infobip.Api.SDK.Tests.WhatsApp
         {
             var request = new WhatsAppTemplateManagementTemplateRequest("name", WhatsAppTemplateManagementTemplateRequest.LanguageEnum.En,
                 WhatsAppTemplateManagementTemplateRequest.CategoryEnum.UTILITY,
-                new WhatsAppTemplateTemplateStructureApiData(new WhatsAppTemplateHeaderApiData(WhatsAppTemplateHeaderApiData.FormatEnum.Text),"My Message", "Footer text"));
+                new WhatsAppTemplateTemplateStructureApiData(new WhatsAppTemplateHeaderApiData(WhatsAppTemplateHeaderApiData.FormatEnum.Text),
+                    new WhatsAppTemplateBodyApiData("My Message"), new WhatsAppTemplateFooterApiData("Footer text"))
+                );
             return request;
         }
 

--- a/src/Infobip.Api.SDK.Tests/WhatsApp/CreateWhatsAppTemplateTests.cs
+++ b/src/Infobip.Api.SDK.Tests/WhatsApp/CreateWhatsAppTemplateTests.cs
@@ -119,7 +119,7 @@ namespace Infobip.Api.SDK.Tests.WhatsApp
         private WhatsAppTemplateManagementTemplateRequest GetRequest()
         {
             var request = new WhatsAppTemplateManagementTemplateRequest("name", WhatsAppTemplateManagementTemplateRequest.LanguageEnum.En,
-                WhatsAppTemplateManagementTemplateRequest.CategoryEnum.ACCOUNTUPDATE,
+                WhatsAppTemplateManagementTemplateRequest.CategoryEnum.UTILITY,
                 new WhatsAppTemplateTemplateStructureApiData(new WhatsAppTemplateHeaderApiData(WhatsAppTemplateHeaderApiData.FormatEnum.Text),"My Message", "Footer text"));
             return request;
         }

--- a/src/Infobip.Api.SDK/Infobip.Api.SDK.csproj
+++ b/src/Infobip.Api.SDK/Infobip.Api.SDK.csproj
@@ -15,7 +15,6 @@
 		<PackageProjectUrl>https://github.com/infobip-community/infobip-api-csharp-sdk/</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/infobip-community/infobip-api-csharp-sdk/</RepositoryUrl>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
-		<Version>1.0.3</Version>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -27,7 +26,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Infobip.Api.SDK/Infobip.Api.SDK.csproj
+++ b/src/Infobip.Api.SDK/Infobip.Api.SDK.csproj
@@ -15,6 +15,7 @@
 		<PackageProjectUrl>https://github.com/infobip-community/infobip-api-csharp-sdk/</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/infobip-community/infobip-api-csharp-sdk/</RepositoryUrl>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<Version>1.0.3</Version>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -26,7 +27,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Infobip.Api.SDK/WhatsApp/Models/WhatsAppTemplateBodyApiData.cs
+++ b/src/Infobip.Api.SDK/WhatsApp/Models/WhatsAppTemplateBodyApiData.cs
@@ -1,0 +1,31 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text;
+
+namespace Infobip.Api.SDK.WhatsApp.Models
+{
+    /// <summary>
+    /// Template structure.
+    /// </summary>
+    public class WhatsAppTemplateBodyApiData
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WhatsAppTemplateBodyApiData" /> class.
+        /// </summary>
+        /// <param name="text">Template body. Can be registered as plain text or text with placeholders. Placeholders have to be correctly formatted and in the correct order, regardless of other sections. Example: {{1}}, {{2}}, {{3}}... (required).</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public WhatsAppTemplateBodyApiData(string text = default)
+        {
+            Text = text ?? throw new ArgumentNullException(nameof(text));
+        }
+        /// <summary>
+        /// Template body text. Can be registered as plain text or text with placeholders. Placeholders have to be correctly formatted and in the correct order, regardless of other sections. Example: {{1}}, {{2}}, {{3}}...
+        /// </summary>
+        /// <value>Template body text. Can be registered as plain text or text with placeholders. Placeholders have to be correctly formatted and in the correct order, regardless of other sections. Example: {{1}}, {{2}}, {{3}}...</value>
+        [JsonProperty("text")]
+        [Required(ErrorMessage = "Body text is required")]
+        public string Text { get; set; }
+    }
+}

--- a/src/Infobip.Api.SDK/WhatsApp/Models/WhatsAppTemplateFooterApiData.cs
+++ b/src/Infobip.Api.SDK/WhatsApp/Models/WhatsAppTemplateFooterApiData.cs
@@ -1,0 +1,31 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text;
+
+namespace Infobip.Api.SDK.WhatsApp.Models
+{
+    /// <summary>
+    /// Template structure.
+    /// </summary>
+    public class WhatsAppTemplateFooterApiData
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WhatsAppTemplateFooterApiData" /> class.
+        /// </summary>
+        /// <param name="text">Template footer. Plain text, up to 60 characters..</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public WhatsAppTemplateFooterApiData(string text = default)
+        {
+            Text = text ?? throw new ArgumentNullException(nameof(text));
+        }
+        /// <summary>
+        /// Template footer. Plain text, up to 60 characters..
+        /// </summary>
+        /// <value>Template footer. Plain text, up to 60 characters..</value>
+        [JsonProperty("text")]
+        [Required(ErrorMessage = "Footer text is required")]
+        public string Text { get; set; }
+    }
+}

--- a/src/Infobip.Api.SDK/WhatsApp/Models/WhatsAppTemplateManagementTemplateRequest.cs
+++ b/src/Infobip.Api.SDK/WhatsApp/Models/WhatsAppTemplateManagementTemplateRequest.cs
@@ -447,70 +447,22 @@ namespace Infobip.Api.SDK.WhatsApp.Models
         public enum CategoryEnum
         {
             /// <summary>
-            /// Enum ACCOUNTUPDATE for value: ACCOUNT_UPDATE
+            /// Enum MARKETING for value: MARKETING
             /// </summary>
-            [EnumMember(Value = "ACCOUNT_UPDATE")]
-            ACCOUNTUPDATE = 1,
+            [EnumMember(Value = "MARKETING")]
+            MARKETING = 1,
 
             /// <summary>
-            /// Enum PAYMENTUPDATE for value: PAYMENT_UPDATE
+            /// Enum AUTHENTICATION for value: AUTHENTICATION
             /// </summary>
-            [EnumMember(Value = "PAYMENT_UPDATE")]
-            PAYMENTUPDATE = 2,
+            [EnumMember(Value = "AUTHENTICATION")]
+            AUTHENTICATION = 2,
 
             /// <summary>
-            /// Enum PERSONALFINANCEUPDATE for value: PERSONAL_FINANCE_UPDATE
+            /// Enum UTILITY for value: UTILITY
             /// </summary>
-            [EnumMember(Value = "PERSONAL_FINANCE_UPDATE")]
-            PERSONALFINANCEUPDATE = 3,
-
-            /// <summary>
-            /// Enum SHIPPINGUPDATE for value: SHIPPING_UPDATE
-            /// </summary>
-            [EnumMember(Value = "SHIPPING_UPDATE")]
-            SHIPPINGUPDATE = 4,
-
-            /// <summary>
-            /// Enum RESERVATIONUPDATE for value: RESERVATION_UPDATE
-            /// </summary>
-            [EnumMember(Value = "RESERVATION_UPDATE")]
-            RESERVATIONUPDATE = 5,
-
-            /// <summary>
-            /// Enum ISSUERESOLUTION for value: ISSUE_RESOLUTION
-            /// </summary>
-            [EnumMember(Value = "ISSUE_RESOLUTION")]
-            ISSUERESOLUTION = 6,
-
-            /// <summary>
-            /// Enum APPOINTMENTUPDATE for value: APPOINTMENT_UPDATE
-            /// </summary>
-            [EnumMember(Value = "APPOINTMENT_UPDATE")]
-            APPOINTMENTUPDATE = 7,
-
-            /// <summary>
-            /// Enum TRANSPORTATIONUPDATE for value: TRANSPORTATION_UPDATE
-            /// </summary>
-            [EnumMember(Value = "TRANSPORTATION_UPDATE")]
-            TRANSPORTATIONUPDATE = 8,
-
-            /// <summary>
-            /// Enum TICKETUPDATE for value: TICKET_UPDATE
-            /// </summary>
-            [EnumMember(Value = "TICKET_UPDATE")]
-            TICKETUPDATE = 9,
-
-            /// <summary>
-            /// Enum ALERTUPDATE for value: ALERT_UPDATE
-            /// </summary>
-            [EnumMember(Value = "ALERT_UPDATE")]
-            ALERTUPDATE = 10,
-
-            /// <summary>
-            /// Enum AUTOREPLY for value: AUTO_REPLY
-            /// </summary>
-            [EnumMember(Value = "AUTO_REPLY")]
-            AUTOREPLY = 11
+            [EnumMember(Value = "UTILITY")]
+            UTILITY = 3,
 
         }
 
@@ -536,12 +488,14 @@ namespace Infobip.Api.SDK.WhatsApp.Models
         /// <param name="language">The language code or locale to use. Multiple templates with different language codes can be registered under the same template name. (required).</param>
         /// <param name="category">Category of the template. (required).</param>
         /// <param name="structure">structure (required).</param>
-        public WhatsAppTemplateManagementTemplateRequest(string name = default, LanguageEnum language = default, CategoryEnum category = default, WhatsAppTemplateTemplateStructureApiData structure = default)
+        /// <param name="allowCategoryChange">Allow changing of category.</param>
+        public WhatsAppTemplateManagementTemplateRequest(string name = default, LanguageEnum language = default, CategoryEnum category = default, WhatsAppTemplateTemplateStructureApiData structure = default, bool allowCategoryChange = default)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
             Language = language;
             Category = category;
             Structure = structure ?? throw new ArgumentNullException(nameof(structure));
+            AllowCategoryChange = allowCategoryChange;
         }
 
         /// <summary>
@@ -559,6 +513,13 @@ namespace Infobip.Api.SDK.WhatsApp.Models
         [JsonProperty("structure")]
         [Required(ErrorMessage = "Structure is required")]
         public WhatsAppTemplateTemplateStructureApiData Structure { get; set; }
+
+        /// <summary>
+        /// Allow category change.
+        /// </summary>
+        /// <value>If set to true, Meta will be able to assign category based on their template guidelines. If omitted, template will not be auto-assigned a category and may get rejected if determined to be miscategorized</value>
+        [JsonProperty("allowCategoryChange")]
+        public bool AllowCategoryChange { get; set; }
 
         /// <summary>
         /// To validate all properties of the instance

--- a/src/Infobip.Api.SDK/WhatsApp/Models/WhatsAppTemplateManagementTemplateResponse.cs
+++ b/src/Infobip.Api.SDK/WhatsApp/Models/WhatsAppTemplateManagementTemplateResponse.cs
@@ -479,8 +479,31 @@ namespace Infobip.Api.SDK.WhatsApp.Models
             /// Enum DISABLED for value: DISABLED
             /// </summary>
             [EnumMember(Value = "DISABLED")]
-            DISABLED = 7
+            DISABLED = 7,
 
+            /// <summary>
+            /// Enum REINSTATED for value: REINSTATED
+            /// </summary>
+            [EnumMember(Value = "REINSTATED")]
+            REINSTATED = 8,
+
+            /// <summary>
+            /// Enum FLAGGED for value: FLAGGED
+            /// </summary>
+            [EnumMember(Value = "FLAGGED")]
+            FLAGGED = 9,
+
+            /// <summary>
+            /// Enum FIRSTPAUSED for value: FIRST_PAUSED
+            /// </summary>
+            [EnumMember(Value = "FIRST_PAUSED")]
+            FIRSTPAUSED = 10,
+
+            /// <summary>
+            /// Enum SECONDPAUSED for value: SECOND_PAUSED
+            /// </summary>
+            [EnumMember(Value = "SECOND_PAUSED")]
+            SECONDPAUSED = 11
         }
 
 
@@ -498,71 +521,22 @@ namespace Infobip.Api.SDK.WhatsApp.Models
         public enum CategoryEnum
         {
             /// <summary>
-            /// Enum ACCOUNTUPDATE for value: ACCOUNT_UPDATE
+            /// Enum MARKETING for value: MARKETING
             /// </summary>
-            [EnumMember(Value = "ACCOUNT_UPDATE")]
-            ACCOUNTUPDATE = 1,
+            [EnumMember(Value = "MARKETING")]
+            MARKETING = 1,
 
             /// <summary>
-            /// Enum PAYMENTUPDATE for value: PAYMENT_UPDATE
+            /// Enum AUTHENTICATION for value: AUTHENTICATION
             /// </summary>
-            [EnumMember(Value = "PAYMENT_UPDATE")]
-            PAYMENTUPDATE = 2,
+            [EnumMember(Value = "AUTHENTICATION")]
+            AUTHENTICATION = 2,
 
             /// <summary>
-            /// Enum PERSONALFINANCEUPDATE for value: PERSONAL_FINANCE_UPDATE
+            /// Enum UTILITY for value: UTILITY
             /// </summary>
-            [EnumMember(Value = "PERSONAL_FINANCE_UPDATE")]
-            PERSONALFINANCEUPDATE = 3,
-
-            /// <summary>
-            /// Enum SHIPPINGUPDATE for value: SHIPPING_UPDATE
-            /// </summary>
-            [EnumMember(Value = "SHIPPING_UPDATE")]
-            SHIPPINGUPDATE = 4,
-
-            /// <summary>
-            /// Enum RESERVATIONUPDATE for value: RESERVATION_UPDATE
-            /// </summary>
-            [EnumMember(Value = "RESERVATION_UPDATE")]
-            RESERVATIONUPDATE = 5,
-
-            /// <summary>
-            /// Enum ISSUERESOLUTION for value: ISSUE_RESOLUTION
-            /// </summary>
-            [EnumMember(Value = "ISSUE_RESOLUTION")]
-            ISSUERESOLUTION = 6,
-
-            /// <summary>
-            /// Enum APPOINTMENTUPDATE for value: APPOINTMENT_UPDATE
-            /// </summary>
-            [EnumMember(Value = "APPOINTMENT_UPDATE")]
-            APPOINTMENTUPDATE = 7,
-
-            /// <summary>
-            /// Enum TRANSPORTATIONUPDATE for value: TRANSPORTATION_UPDATE
-            /// </summary>
-            [EnumMember(Value = "TRANSPORTATION_UPDATE")]
-            TRANSPORTATIONUPDATE = 8,
-
-            /// <summary>
-            /// Enum TICKETUPDATE for value: TICKET_UPDATE
-            /// </summary>
-            [EnumMember(Value = "TICKET_UPDATE")]
-            TICKETUPDATE = 9,
-
-            /// <summary>
-            /// Enum ALERTUPDATE for value: ALERT_UPDATE
-            /// </summary>
-            [EnumMember(Value = "ALERT_UPDATE")]
-            ALERTUPDATE = 10,
-
-            /// <summary>
-            /// Enum AUTOREPLY for value: AUTO_REPLY
-            /// </summary>
-            [EnumMember(Value = "AUTO_REPLY")]
-            AUTOREPLY = 11
-
+            [EnumMember(Value = "UTILITY")]
+            UTILITY = 3,
         }
 
 
@@ -572,6 +546,44 @@ namespace Infobip.Api.SDK.WhatsApp.Models
         /// <value>Category of the template.</value>
         [JsonProperty("category")]
         public CategoryEnum? Category { get; set; }
+        /// <summary>
+        /// Quality of the template.
+        /// </summary>
+        /// <value>Quality of the template.</value>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public enum QualityEnum
+        {
+            /// <summary>
+            /// Enum HIGH for value: HIGH
+            /// </summary>
+            [EnumMember(Value = "HIGH")]
+            HIGH = 1,
+
+            /// <summary>
+            /// Enum MEDIUM for value: MEDIUM
+            /// </summary>
+            [EnumMember(Value = "MEDIUM")]
+            MEDIUM = 2,
+
+            /// <summary>
+            /// Enum LOW for value: LOW
+            /// </summary>
+            [EnumMember(Value = "LOW")]
+            LOW = 3,
+
+            /// <summary>
+            /// Enum UNKNOWN for value: UNKNOWN
+            /// </summary>
+            [EnumMember(Value = "UNKNOWN")]
+            UNKNOWN = 4
+        }
+
+        /// <summary>
+        /// Quality of the template.
+        /// </summary>
+        /// <value>Quality of the template.</value>
+        [JsonProperty("quality")]
+        public QualityEnum? Quality { get; set; }
 
         /// <summary>
         /// Template ID.

--- a/src/Infobip.Api.SDK/WhatsApp/Models/WhatsAppTemplateTemplateStructureApiData.cs
+++ b/src/Infobip.Api.SDK/WhatsApp/Models/WhatsAppTemplateTemplateStructureApiData.cs
@@ -58,7 +58,7 @@ namespace Infobip.Api.SDK.WhatsApp.Models
         /// <param name="body">Template body. Can be registered as plain text or text with placeholders. Placeholders have to be correctly formatted and in the correct order, regardless of other sections. Example: {{1}}, {{2}}, {{3}}... (required).</param>
         /// <param name="footer">Template footer. Plain text, up to 60 characters..</param>
         /// <param name="buttons">Template buttons. Can be either up to 3 &#x60;quick reply&#x60; buttons or up to 2 &#x60;call to action&#x60; buttons. Call to action buttons must be unique in type..</param>
-        public WhatsAppTemplateTemplateStructureApiData(WhatsAppTemplateHeaderApiData header = default, string body = default, string footer = default, List<WhatsAppTemplateButtonApiData> buttons = default)
+        public WhatsAppTemplateTemplateStructureApiData(WhatsAppTemplateHeaderApiData header = default, WhatsAppTemplateBodyApiData body = default, WhatsAppTemplateFooterApiData footer = default, List<WhatsAppTemplateButtonApiData> buttons = default)
         {
             Body = body ?? throw new ArgumentNullException(nameof(body));
             Header = header;
@@ -78,15 +78,14 @@ namespace Infobip.Api.SDK.WhatsApp.Models
         /// <value>Template body. Can be registered as plain text or text with placeholders. Placeholders have to be correctly formatted and in the correct order, regardless of other sections. Example: {{1}}, {{2}}, {{3}}...</value>
         [JsonProperty("body")]
         [Required(ErrorMessage = "Body is required")]
-        public string Body { get; set; }
+        public WhatsAppTemplateBodyApiData Body { get; set; }
 
         /// <summary>
-        /// Template footer. Plain text, up to 60 characters.
+        /// Template footer.
         /// </summary>
-        /// <value>Template footer. Plain text, up to 60 characters.</value>
+        /// <value>Template footer.</value>
         [JsonProperty("footer")]
-        [MaxLength(60)]
-        public string Footer { get; set; }
+        public WhatsAppTemplateFooterApiData Footer { get; set; }
 
         /// <summary>
         /// Template buttons. Can be either up to 3 &#x60;quick reply&#x60; buttons or up to 2 &#x60;call to action&#x60; buttons. Call to action buttons must be unique in type.

--- a/src/Infobip.Api.SDK/WhatsApp/WhatsAppEndpoints.cs
+++ b/src/Infobip.Api.SDK/WhatsApp/WhatsAppEndpoints.cs
@@ -419,7 +419,7 @@ namespace Infobip.Api.SDK.WhatsApp
                 throw new InfobipRequestNotValidException($"Missing required parameter '{nameof(sender)}'.", new List<ValidationResult>());
             }
 
-            using (var request = new HttpRequestMessage(HttpMethod.Get, $"whatsapp/1/senders/{sender}/templates"))
+            using (var request = new HttpRequestMessage(HttpMethod.Get, $"whatsapp/2/senders/{sender}/templates"))
             {
                 request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
@@ -446,7 +446,7 @@ namespace Infobip.Api.SDK.WhatsApp
 
             var serializedPayload = JsonConvert.SerializeObject(requestPayload);
 
-            using (var request = new HttpRequestMessage(HttpMethod.Post, "whatsapp/1/senders/{sender}/templates"))
+            using (var request = new HttpRequestMessage(HttpMethod.Post, "whatsapp/2/senders/{sender}/templates"))
             {
                 request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 request.Content = new StringContent(serializedPayload);


### PR DESCRIPTION
API version 1 for get templates and create template have been deprecated since the beginning  of the year, I've updated the methods to use v2 API endpoints.

All models and tests involved have been updated by this pull request.